### PR TITLE
Fix enumerate_vol skipping defs that share a (column, defno) position

### DIFF
--- a/lib/eby_utils.rb
+++ b/lib/eby_utils.rb
@@ -134,22 +134,24 @@ module EbyUtils
       end
       { orphan: orphan, sibling: sibling, sibling_ordinal: sibling.ordinal }
     end
-    # Process from highest sibling ordinal to lowest so each shift only displaces
-    # positions above the current insertion point, leaving lower insert points intact.
-    pairs.sort_by { |p| -p[:sibling_ordinal] }.each do |pair|
-      orphan, sibling, n = pair.values_at(:orphan, :sibling, :sibling_ordinal)
-      # Compare in dictionary order: consonants (strip nikkud), then full defhead, then ID
-      cmp = orphan.defhead.strip_nikkud <=> sibling.defhead.strip_nikkud
-      cmp = orphan.defhead <=> sibling.defhead if cmp == 0
-      cmp = orphan.id     <=> sibling.id       if cmp == 0
-      if cmp < 0
-        EbyDef.where(volume: vol).where('ordinal >= ?', n).where.not(id: orphan.id).update_all('ordinal = ordinal + 1')
-        orphan.update(ordinal: n)
-        puts "Note: def ID=#{orphan.id} (#{orphan.defhead}) inserted before sibling ID=#{sibling.id} at ordinal #{n}"
-      else
-        EbyDef.where(volume: vol).where('ordinal > ?', n).where.not(id: orphan.id).update_all('ordinal = ordinal + 1')
-        orphan.update(ordinal: n + 1)
-        puts "Note: def ID=#{orphan.id} (#{orphan.defhead}) inserted after sibling ID=#{sibling.id} at ordinal #{n + 1}"
+    EbyDef.transaction do
+      # Process from highest sibling ordinal to lowest so each shift only displaces
+      # positions above the current insertion point, leaving lower insert points intact.
+      pairs.sort_by { |p| -p[:sibling_ordinal] }.each do |pair|
+        orphan, sibling, n = pair.values_at(:orphan, :sibling, :sibling_ordinal)
+        # Compare in dictionary order: consonants (strip nikkud), then full defhead, then ID
+        cmp = orphan.defhead.strip_nikkud <=> sibling.defhead.strip_nikkud
+        cmp = orphan.defhead <=> sibling.defhead if cmp == 0
+        cmp = orphan.id     <=> sibling.id       if cmp == 0
+        if cmp < 0
+          EbyDef.where(volume: vol).where('ordinal >= ?', n).where.not(id: orphan.id).update_all('ordinal = ordinal + 1')
+          orphan.update!(ordinal: n)
+          puts "Note: def ID=#{orphan.id} (#{orphan.defhead}) inserted before sibling ID=#{sibling.id} at ordinal #{n}"
+        else
+          EbyDef.where(volume: vol).where('ordinal > ?', n).where.not(id: orphan.id).update_all('ordinal = ordinal + 1')
+          orphan.update!(ordinal: n + 1)
+          puts "Note: def ID=#{orphan.id} (#{orphan.defhead}) inserted after sibling ID=#{sibling.id} at ordinal #{n + 1}"
+        end
       end
     end
   end

--- a/lib/eby_utils.rb
+++ b/lib/eby_utils.rb
@@ -118,7 +118,10 @@ module EbyUtils
     # Pair each orphaned def (missed by chain traversal because it shares a
     # (column, defno) with another def) with the enumerated sibling at that position.
     pairs = EbyDef.where(volume: vol, ordinal: nil).filter_map do |orphan|
-      next if orphan.part_images.empty?
+      if orphan.part_images.empty?
+        puts "WARNING: def ID=#{orphan.id} (#{orphan.defhead}) has nil ordinal but no part_images; cannot determine (column, defno) position"
+        next
+      end
       first_part = orphan.part_images.first
       sibling = first_part.colimg.def_part_images
                   .where(defno: first_part.defno)

--- a/lib/eby_utils.rb
+++ b/lib/eby_utils.rb
@@ -115,6 +115,40 @@ module EbyUtils
     if last_predecessor != last_def_for_vol(vol)
       puts "Incomplete enumeration detected: last successfully enumerated def was ID: #{last_predecessor.id}, #{last_predecessor.defhead}"
     end
+    # Pair each orphaned def (missed by chain traversal because it shares a
+    # (column, defno) with another def) with the enumerated sibling at that position.
+    pairs = EbyDef.where(volume: vol, ordinal: nil).filter_map do |orphan|
+      next if orphan.part_images.empty?
+      first_part = orphan.part_images.first
+      sibling = first_part.colimg.def_part_images
+                  .where(defno: first_part.defno)
+                  .where.not(thedef: orphan.id)
+                  .filter_map(&:eby_def)
+                  .find { |s| s.ordinal.present? }
+      unless sibling
+        puts "WARNING: def ID=#{orphan.id} (#{orphan.defhead}) has nil ordinal and no enumerated sibling at its position"
+        next
+      end
+      { orphan: orphan, sibling: sibling, sibling_ordinal: sibling.ordinal }
+    end
+    # Process from highest sibling ordinal to lowest so each shift only displaces
+    # positions above the current insertion point, leaving lower insert points intact.
+    pairs.sort_by { |p| -p[:sibling_ordinal] }.each do |pair|
+      orphan, sibling, n = pair.values_at(:orphan, :sibling, :sibling_ordinal)
+      # Compare in dictionary order: consonants (strip nikkud), then full defhead, then ID
+      cmp = orphan.defhead.strip_nikkud <=> sibling.defhead.strip_nikkud
+      cmp = orphan.defhead <=> sibling.defhead if cmp == 0
+      cmp = orphan.id     <=> sibling.id       if cmp == 0
+      if cmp < 0
+        EbyDef.where(volume: vol).where('ordinal >= ?', n).where.not(id: orphan.id).update_all('ordinal = ordinal + 1')
+        orphan.update(ordinal: n)
+        puts "Note: def ID=#{orphan.id} (#{orphan.defhead}) inserted before sibling ID=#{sibling.id} at ordinal #{n}"
+      else
+        EbyDef.where(volume: vol).where('ordinal > ?', n).where.not(id: orphan.id).update_all('ordinal = ordinal + 1')
+        orphan.update(ordinal: n + 1)
+        puts "Note: def ID=#{orphan.id} (#{orphan.defhead}) inserted after sibling ID=#{sibling.id} at ordinal #{n + 1}"
+      end
+    end
   end
   def html_entities_coder
     @html_entities_coder ||= HTMLEntities.new

--- a/spec/lib/eby_utils_spec.rb
+++ b/spec/lib/eby_utils_spec.rb
@@ -234,7 +234,72 @@ RSpec.describe EbyUtils do
     # describe '#first_def_for_vol'
     # describe '#last_def_for_vol'
     # describe '#first_def'
-    # describe '#enumerate_vol'
     # describe '#makedef'
+  end
+
+  describe '#enumerate_vol' do
+    # Use a volume number unlikely to collide with other test data.
+    # secondpagenum=1000 ensures col_from_col finds no "next scan" when it
+    # increments col.pagenum (1) by 1, so the traversal correctly terminates.
+    let(:vol) { 999 }
+    let(:scan) do
+      create(:eby_scan_image, volume: vol, firstpagenum: 1, secondpagenum: 1000, status: 'Partitioned')
+    end
+    let(:col) do
+      create(:eby_column_image, scan: scan, volume: vol, colnum: 1, pagenum: 1, status: 'Partitioned')
+    end
+
+    before { col } # triggers lazy scan → col creation before any defs
+
+    def make_def(defhead, defno)
+      d = create(:eby_def, volume: vol, defhead: defhead)
+      create(:eby_def_part_image, eby_def: d, colimg: col, defno: defno, partnum: 1)
+      d
+    end
+
+    it 'assigns sequential ordinals to a chain of defs in one column' do
+      d1 = make_def('אבג', 0)
+      d2 = make_def('בגד', 1)
+      d3 = make_def('גדה', 2)
+
+      enumerate_vol(vol)
+
+      expect(d1.reload.ordinal).to eq(1)
+      expect(d2.reload.ordinal).to eq(2)
+      expect(d3.reload.ordinal).to eq(3)
+    end
+
+    context 'when two defs share the same (column, defno)' do
+      # def_part_by_defno uses .first, so the lower-id def becomes the canonical
+      # and the higher-id def is the orphan that enumerate_vol must place.
+
+      it 'inserts an alphabetically-later orphan immediately after its sibling' do
+        d1     = make_def('אבג', 0)
+        d2     = make_def('בגד', 1)  # canonical (lower id)
+        d_twin = make_def('גגד', 1)  # orphan; 'ג' > 'ב' → sorts after d2
+        d3     = make_def('דהו', 2)
+
+        enumerate_vol(vol)
+
+        expect(d1.reload.ordinal).to eq(1)
+        expect(d2.reload.ordinal).to eq(2)
+        expect(d_twin.reload.ordinal).to eq(3)
+        expect(d3.reload.ordinal).to eq(4)
+      end
+
+      it 'inserts an alphabetically-earlier orphan immediately before its sibling' do
+        d1     = make_def('בבג', 0)
+        d2     = make_def('בגד', 1)  # canonical (lower id)
+        d_twin = make_def('אגד', 1)  # orphan; 'א' < 'ב' → sorts before d2
+        d3     = make_def('גדה', 2)
+
+        enumerate_vol(vol)
+
+        expect(d1.reload.ordinal).to eq(1)
+        expect(d_twin.reload.ordinal).to eq(2)
+        expect(d2.reload.ordinal).to eq(3)
+        expect(d3.reload.ordinal).to eq(4)
+      end
+    end
   end
 end


### PR DESCRIPTION
## Summary

- `enumerate_vol` traverses defs via `successor_def` → `def_part_by_defno` → `.first`. When two `EbyDef` records share the same `(coldefimg_id, defno)` pair (duplicate `EbyDefPartImage` entries, likely from re-partitioning), only one def per slot is ever reachable by the chain — the other ends up with `nil` ordinal.
- After the chain traversal, the fix collects these orphaned defs, pairs each with its enumerated sibling at the same position, and inserts it in dictionary order (nikkud-stripped consonants → full defhead → ID tiebreaker).
- Pairs are processed from **highest ordinal to lowest** so each bulk-shift only displaces positions above the current insertion point, leaving lower insert points undisturbed.

## Test plan

- [ ] Confirm 4 affected defs in volume 2 (IDs 54638, 54639, 54954, 54955) now receive correct ordinals after `enumerate_vol(2)`
- [ ] Confirm each orphan is placed immediately adjacent to its sibling, in the correct relative order
- [ ] Run `bundle exec rspec spec/lib/eby_utils_spec.rb spec/models/eby_def_spec.rb` — 133 examples, 0 failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)