### PR TITLE
Fix enumerate_vol: place isolated orphans skipped by spanning def chain

### DIFF
--- a/lib/eby_utils.rb
+++ b/lib/eby_utils.rb
@@ -159,23 +159,26 @@ module EbyUtils
       # defnos unvisited.  Process in physical reading order so each orphan's predecessor
       # is already placed when we get to it.
       isolated = EbyDef.where(volume: vol, ordinal: nil)
+                       .includes(part_images: :colimg)
                        .select { |orphan| orphan.part_images.any? }
                        .sort_by { |orphan|
                          p = orphan.part_images.first
                          c = p.colimg
-                         [c.pagenum, c.colnum, p.defno]
+                         [c.pagenum, c.colnum, p.defno, orphan.id]
                        }
       isolated.each do |orphan|
         first_part = orphan.part_images.first
         col = first_part.colimg
         defno = first_part.defno
 
-        # Nearest predecessor in the same column that has an ordinal (re-query for freshness)
-        pred_part = col.def_part_images
-                       .where('defno < ?', defno)
-                       .order('defno DESC')
-                       .to_a
-                       .find { |p| EbyDef.where(id: p.thedef).where.not(ordinal: nil).exists? }
+        # Single query: nearest predecessor in the same column that has an ordinal.
+        # Re-query eby_defs via join to pick up ordinals freshly assigned in this loop.
+        pred_part = EbyDefPartImage
+                      .joins("INNER JOIN eby_defs ON eby_defs.id = eby_def_part_images.thedef AND eby_defs.ordinal IS NOT NULL")
+                      .where(coldefimg_id: col.id)
+                      .where('eby_def_part_images.defno < ?', defno)
+                      .order('eby_def_part_images.defno DESC')
+                      .first
 
         if pred_part
           ref_ordinal = EbyDef.find(pred_part.thedef).ordinal
@@ -183,12 +186,13 @@ module EbyUtils
           orphan.update!(ordinal: ref_ordinal + 1)
           puts "Note: def ID=#{orphan.id} (#{orphan.defhead}) inserted after def ID=#{pred_part.thedef} at ordinal #{orphan.ordinal}"
         else
-          # No predecessor — find the nearest successor with an ordinal
-          succ_part = col.def_part_images
-                         .where('defno > ?', defno)
-                         .order('defno ASC')
-                         .to_a
-                         .find { |p| EbyDef.where(id: p.thedef).where.not(ordinal: nil).exists? }
+          # No predecessor — single query for nearest successor with an ordinal
+          succ_part = EbyDefPartImage
+                        .joins("INNER JOIN eby_defs ON eby_defs.id = eby_def_part_images.thedef AND eby_defs.ordinal IS NOT NULL")
+                        .where(coldefimg_id: col.id)
+                        .where('eby_def_part_images.defno > ?', defno)
+                        .order('eby_def_part_images.defno ASC')
+                        .first
           if succ_part
             ref_def = EbyDef.find(succ_part.thedef)
             ref_ordinal = ref_def.ordinal

--- a/lib/eby_utils.rb
+++ b/lib/eby_utils.rb
@@ -135,7 +135,7 @@ module EbyUtils
       { orphan: orphan, sibling: sibling, sibling_ordinal: sibling.ordinal }
     end
     EbyDef.transaction do
-      # Process from highest sibling ordinal to lowest so each shift only displaces
+      # Pass 1: process from highest sibling ordinal to lowest so each shift only displaces
       # positions above the current insertion point, leaving lower insert points intact.
       pairs.sort_by { |p| -p[:sibling_ordinal] }.each do |pair|
         orphan, sibling, n = pair.values_at(:orphan, :sibling, :sibling_ordinal)
@@ -151,6 +151,63 @@ module EbyUtils
           EbyDef.where(volume: vol).where('ordinal > ?', n).where.not(id: orphan.id).update_all('ordinal = ordinal + 1')
           orphan.update!(ordinal: n + 1)
           puts "Note: def ID=#{orphan.id} (#{orphan.defhead}) inserted after sibling ID=#{sibling.id} at ordinal #{n + 1}"
+        end
+      end
+
+      # Pass 2: handle defs skipped because a multi-column spanning def jumped over their
+      # column, or because a spanning continuation landed at defno>0 leaving earlier
+      # defnos unvisited.  Process in physical reading order so each orphan's predecessor
+      # is already placed when we get to it.
+      isolated = EbyDef.where(volume: vol, ordinal: nil)
+                       .select { |orphan| orphan.part_images.any? }
+                       .sort_by { |orphan|
+                         p = orphan.part_images.first
+                         c = p.colimg
+                         [c.pagenum, c.colnum, p.defno]
+                       }
+      isolated.each do |orphan|
+        first_part = orphan.part_images.first
+        col = first_part.colimg
+        defno = first_part.defno
+
+        # Nearest predecessor in the same column that has an ordinal (re-query for freshness)
+        pred_part = col.def_part_images
+                       .where('defno < ?', defno)
+                       .order('defno DESC')
+                       .to_a
+                       .find { |p| EbyDef.where(id: p.thedef).where.not(ordinal: nil).exists? }
+
+        if pred_part
+          ref_ordinal = EbyDef.find(pred_part.thedef).ordinal
+          EbyDef.where(volume: vol).where('ordinal > ?', ref_ordinal).where.not(id: orphan.id).update_all('ordinal = ordinal + 1')
+          orphan.update!(ordinal: ref_ordinal + 1)
+          puts "Note: def ID=#{orphan.id} (#{orphan.defhead}) inserted after def ID=#{pred_part.thedef} at ordinal #{orphan.ordinal}"
+        else
+          # No predecessor — find the nearest successor with an ordinal
+          succ_part = col.def_part_images
+                         .where('defno > ?', defno)
+                         .order('defno ASC')
+                         .to_a
+                         .find { |p| EbyDef.where(id: p.thedef).where.not(ordinal: nil).exists? }
+          if succ_part
+            ref_def = EbyDef.find(succ_part.thedef)
+            ref_ordinal = ref_def.ordinal
+            if succ_part.partnum > 1
+              # Successor is a continuation from a previous column; that def's logical
+              # position is determined by where it started, not here.  Place the orphan
+              # (which begins in this column) after the continuation.
+              EbyDef.where(volume: vol).where('ordinal > ?', ref_ordinal).where.not(id: orphan.id).update_all('ordinal = ordinal + 1')
+              orphan.update!(ordinal: ref_ordinal + 1)
+              puts "Note: def ID=#{orphan.id} (#{orphan.defhead}) inserted after continuation ID=#{ref_def.id} at ordinal #{orphan.ordinal}"
+            else
+              # Successor starts here; orphan belongs before it
+              EbyDef.where(volume: vol).where('ordinal >= ?', ref_ordinal).where.not(id: orphan.id).update_all('ordinal = ordinal + 1')
+              orphan.update!(ordinal: ref_ordinal)
+              puts "Note: def ID=#{orphan.id} (#{orphan.defhead}) inserted before def ID=#{ref_def.id} at ordinal #{orphan.ordinal}"
+            end
+          else
+            puts "WARNING: def ID=#{orphan.id} (#{orphan.defhead}) could not be placed - no anchor found in column #{col.id}"
+          end
         end
       end
     end

--- a/spec/lib/eby_utils_spec.rb
+++ b/spec/lib/eby_utils_spec.rb
@@ -301,5 +301,90 @@ RSpec.describe EbyUtils do
         expect(d3.reload.ordinal).to eq(4)
       end
     end
+
+    context 'when a spanning def jumps over an intermediate column (pattern 2)' do
+      # Models: def_span spans col_a → col_b → col_c.
+      # successor_def uses part_images.last (= col_c), so col_b's defs d_mid1/d_mid2
+      # are never visited by the chain and must be placed by Pass 2.
+      # scan2 gets secondpagenum: 2000 so last_def_for_vol resolves to scan2 (not scan).
+      let(:scan2) do
+        create(:eby_scan_image, volume: vol, firstpagenum: 2, secondpagenum: 2000, status: 'Partitioned')
+      end
+      # col_a IS col — override outer let so the outer `before { col }` creates col_a,
+      # preventing a duplicate column in scan.
+      let(:col_a) { create(:eby_column_image, scan: scan, volume: vol, colnum: 1, pagenum: 1, status: 'Partitioned') }
+      let(:col)   { col_a }
+      let(:col_b) { create(:eby_column_image, scan: scan2, volume: vol, colnum: 1, pagenum: 2, status: 'Partitioned') }
+      let(:col_c) { create(:eby_column_image, scan: scan2, volume: vol, colnum: 2, pagenum: 2, status: 'Partitioned') }
+
+      before { col_b; col_c }
+
+      it 'places defs in the skipped column at the correct ordinals' do
+        # col_a: defno=0 → d_before, defno=1 → def_span (part 1)
+        d_before = create(:eby_def, volume: vol, defhead: 'אבג')
+        create(:eby_def_part_image, eby_def: d_before, colimg: col_a, defno: 0, partnum: 1)
+
+        def_span = create(:eby_def, volume: vol, defhead: 'בגד')
+        create(:eby_def_part_image, eby_def: def_span, colimg: col_a, defno: 1, partnum: 1)  # starts in col_a
+        create(:eby_def_part_image, eby_def: def_span, colimg: col_b, defno: 0, partnum: 2)  # continues in col_b
+        create(:eby_def_part_image, eby_def: def_span, colimg: col_c, defno: 0, partnum: 3)  # ends in col_c
+
+        # col_b also has two defs skipped by the chain
+        d_mid1 = create(:eby_def, volume: vol, defhead: 'גדה')
+        create(:eby_def_part_image, eby_def: d_mid1, colimg: col_b, defno: 1, partnum: 1)
+
+        d_mid2 = create(:eby_def, volume: vol, defhead: 'דהו')
+        create(:eby_def_part_image, eby_def: d_mid2, colimg: col_b, defno: 2, partnum: 1)
+
+        # col_c: defno=1 → d_after (chain resumes here via def_span.part_images.last)
+        d_after = create(:eby_def, volume: vol, defhead: 'הוז')
+        create(:eby_def_part_image, eby_def: d_after, colimg: col_c, defno: 1, partnum: 1)
+
+        enumerate_vol(vol)
+
+        expect(d_before.reload.ordinal).to eq(1)
+        expect(def_span.reload.ordinal).to eq(2)
+        expect(d_mid1.reload.ordinal).to  eq(3)
+        expect(d_mid2.reload.ordinal).to  eq(4)
+        expect(d_after.reload.ordinal).to eq(5)
+      end
+    end
+
+    context 'when a spanning continuation lands at defno>0, skipping defno=0 (pattern 3)' do
+      # def_span starts in col_a at defno=0 and continues in col_b at defno=1.
+      # successor_def picks up from col_b defno=1+1=2, so d_early (col_b defno=0)
+      # is never visited and must be placed by Pass 2.
+      # scan2 gets secondpagenum: 2000 so last_def_for_vol resolves to scan2 (not scan).
+      let(:scan2) do
+        create(:eby_scan_image, volume: vol, firstpagenum: 2, secondpagenum: 2000, status: 'Partitioned')
+      end
+      # col_a IS col — override outer let so the outer `before { col }` creates col_a,
+      # preventing a duplicate column in scan.
+      let(:col_a) { create(:eby_column_image, scan: scan, volume: vol, colnum: 1, pagenum: 1, status: 'Partitioned') }
+      let(:col)   { col_a }
+      let(:col_b) { create(:eby_column_image, scan: scan2, volume: vol, colnum: 1, pagenum: 2, status: 'Partitioned') }
+
+      before { col_b }
+
+      it 'places the skipped defno=0 entry after the continuation' do
+        def_span = create(:eby_def, volume: vol, defhead: 'בגד')
+        create(:eby_def_part_image, eby_def: def_span, colimg: col_a, defno: 0, partnum: 1)  # starts col_a
+        create(:eby_def_part_image, eby_def: def_span, colimg: col_b, defno: 1, partnum: 2)  # continues at defno=1
+
+        # col_b defno=0: a def that begins here, physically before the continuation
+        d_early = create(:eby_def, volume: vol, defhead: 'אבג')
+        create(:eby_def_part_image, eby_def: d_early, colimg: col_b, defno: 0, partnum: 1)
+
+        # col_b defno=2: normal def, resumed by the chain after def_span
+        d_after = create(:eby_def, volume: vol, defhead: 'גדה')
+        create(:eby_def_part_image, eby_def: d_after, colimg: col_b, defno: 2, partnum: 1)
+
+        enumerate_vol(vol)
+
+        expect(def_span.reload.ordinal).to eq(1)
+        expect(d_early.reload.ordinal).to  eq(2)
+        expect(d_after.reload.ordinal).to  eq(3)
+      end
+    end
   end
 end


### PR DESCRIPTION
## Summary

- Adds **Pass 2** to `enumerate_vol` to handle nil-ordinal defs that aren't caught by Pass 1 (the duplicate-defno sibling fix from #71)
- Two new root-cause patterns identified in volumes 3 and 5:
  - **Pattern 2** (vol 3): a def spanning 3 columns causes `successor_def` to jump from the last column, entirely skipping defs in the intermediate column
  - **Pattern 3** (vol 5): a spanning def's continuation lands at `defno > 0` in the target column, leaving `defno=0` unvisited
- Pass 2 processes remaining nil-ordinal defs in physical reading order `(pagenum, colnum, defno)` and inserts each after its nearest predecessor in the same column — or, when none exists, before/after the nearest successor depending on whether it starts in that column (`partnum=1`) or continues from a previous one (`partnum > 1`)

## Test plan

- [x] New integration spec: "when a spanning def jumps over an intermediate column (pattern 2)" — verifies all 5 defs get correct sequential ordinals
- [x] New integration spec: "when a spanning continuation lands at defno>0, skipping defno=0 (pattern 3)" — verifies the skipped def is placed after the continuation
- [x] All 585 existing specs continue to pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)